### PR TITLE
feat(bluemap): Integrate BlueMap support into vanish service with API delegation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(libs.jaxbRuntime)
     implementation(libs.postgresql)
     implementation(libs.apacheCommons)
+    compileOnly(libs.bluemapApi)
 
     // Testing
     testImplementation(platform(libs.mycelium.bom))
@@ -122,6 +123,9 @@ paper {
             required = false
         }
         register("ProtocolLib") {
+            required = false
+        }
+        register("BlueMap") {
             required = false
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ dependencyResolutionManagement {
         maven("https://repo.papermc.io/repository/maven-public/")
         maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
         maven("https://repo.dmulloy2.net/repository/public/")
+        maven ("https://repo.bluecolored.de/releases")
         maven {
             name = "OneLiteFeatherRepository"
             url = uri("https://repo.onelitefeather.dev/onelitefeather")
@@ -32,6 +33,7 @@ dependencyResolutionManagement {
             version("paper", "1.21.10-R0.1-SNAPSHOT")
             version("luckperms", "5.5")
             version("protocolLib", "5.3.0")
+            version("bluemapApi", "2.7.6")
             version("jaxbRuntime", "4.0.6")
             version("postgresql", "42.7.8")
             version("apacheCommons", "3.19.0")
@@ -48,6 +50,7 @@ dependencyResolutionManagement {
             library("paper", "io.papermc.paper", "paper-api").versionRef("paper")
             library("luckperms", "net.luckperms", "api").versionRef("luckperms")
             library("protocolLib", "com.comphenix.protocol", "ProtocolLib").versionRef("protocolLib")
+            library("bluemapApi", "de.bluecolored", "bluemap-api").versionRef("bluemapApi")
 
             library("cloudPaper", "org.incendo", "cloud-paper").version("2.0.0-SNAPSHOT")
             library("cloudAnnotations", "org.incendo", "cloud-annotations").version("2.0.0")

--- a/src/main/java/net/onelitefeather/stardust/service/DelegatedBlueMapVanishService.java
+++ b/src/main/java/net/onelitefeather/stardust/service/DelegatedBlueMapVanishService.java
@@ -1,0 +1,55 @@
+package net.onelitefeather.stardust.service;
+
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import net.onelitefeather.stardust.api.PlayerVanishService;
+import org.bukkit.entity.Player;
+
+public final class DelegatedBlueMapVanishService implements PlayerVanishService<Player> {
+
+    private final PlayerVanishService<Player> delegate;
+
+    public DelegatedBlueMapVanishService(PlayerVanishService<Player> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void hidePlayer(Player player) {
+        this.delegate.hidePlayer(player);
+    }
+
+    @Override
+    public void showPlayer(Player player) {
+        this.delegate.showPlayer(player);
+    }
+
+    @Override
+    public boolean toggle(Player player) {
+        return this.delegate.toggle(player);
+    }
+
+    @Override
+    public boolean isVanished(Player player) {
+        return this.delegate.isVanished(player);
+    }
+
+    @Override
+    public void setVanished(Player player, boolean vanished) {
+        BlueMapAPI.getInstance().map(BlueMapAPI::getWebApp).ifPresent(api -> api.setPlayerVisibility(player.getUniqueId(), vanished));
+        this.delegate.setVanished(player, vanished);
+    }
+
+    @Override
+    public boolean handlePlayerJoin(Player player) {
+        return this.delegate.handlePlayerJoin(player);
+    }
+
+    @Override
+    public void handlePlayerQuit(Player player) {
+        this.delegate.handlePlayerQuit(player);
+    }
+
+    @Override
+    public boolean canSee(Player player, Player target) {
+        return this.delegate.canSee(player, target);
+    }
+}

--- a/src/main/java/net/onelitefeather/stardust/service/UserService.java
+++ b/src/main/java/net/onelitefeather/stardust/service/UserService.java
@@ -7,6 +7,7 @@ import net.onelitefeather.stardust.task.UserTask;
 import net.onelitefeather.stardust.user.User;
 import net.onelitefeather.stardust.user.UserProperty;
 import net.onelitefeather.stardust.user.UserPropertyType;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 import org.hibernate.SessionFactory;
@@ -20,6 +21,8 @@ import java.util.logging.Level;
 
 public final class UserService {
 
+    private static final String PLUGIN_BLUEMAP_ENABLED = "BlueMap";
+
     private final StardustPlugin plugin;
     private final BukkitTask userTask;
     private final PlayerVanishService<Player> vanishService;
@@ -28,7 +31,11 @@ public final class UserService {
     public UserService(StardustPlugin plugin) {
         this.plugin = plugin;
         this.userTask = plugin.getServer().getScheduler().runTaskTimerAsynchronously(plugin, new UserTask(plugin), 20L, 20L);
-        this.vanishService = new BukkitPlayerVanishService(this, plugin);
+        if (Bukkit.getPluginManager().isPluginEnabled(PLUGIN_BLUEMAP_ENABLED)) {
+            this.vanishService = new DelegatedBlueMapVanishService(new BukkitPlayerVanishService(this, plugin));
+        } else {
+            this.vanishService = new BukkitPlayerVanishService(this, plugin);
+        }
         this.databaseService = plugin.getDatabaseService();
     }
 


### PR DESCRIPTION
## Overview
Bluemap has a webservice for their map which allows you to see players on a 3D map. This PR ensures that vanished players are also vanished there as well.

The BlueMap API is used to achieve this goal, adding a new DelegatedBlueMapVanishService along with some plugin enabled check. BlueMap is also declared as a soft dependency as it is optional for StarDust.

### Submitter Checklist
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/OneLiteFeatherNET/.github/blob/main/CONTRIBUTING.md).

