### PR TITLE
Update Paper dependency to version 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
+        languageVersion.set(JavaLanguageVersion.of(25))
     }
 }
 
@@ -60,7 +60,7 @@ tasks {
         finalizedBy(rootProject.tasks.jacocoTestReport)
     }
     runServer {
-        minecraftVersion("1.21.10")
+        minecraftVersion("26.1.2")
         jvmArgs("-Dcom.mojang.eula.agree=true")
     }
     jacocoTestReport {
@@ -74,7 +74,7 @@ tasks {
 
 paper {
     main = "${rootProject.group}.stardust.StardustPlugin"
-    apiVersion = "1.21"
+    apiVersion = "26.1.2"
     name = "Stardust"
     load = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.PluginLoadOrder.POSTWORLD
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,7 +33,7 @@ dependencyResolutionManagement {
         create("libs") {
 
             version("hibernate", "7.3.8.Final")
-            version("paper", "1.21.11-R0.1-SNAPSHOT")
+            version("paper", "26.1.2.build.+")
             version("luckperms", "5.5")
             version("protocolLib", "5.3.0")
             version("bluemapApi", "2.7.8")


### PR DESCRIPTION
## Overview
This pull request updates the Paper Api Dependency to 26.1.2

### Submitter Checklist
- [X} Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [X] Ensure that the pull request title represents the desired changelog entry.
- [X] New public fields and methods are annotated with `@since TODO`.
- [X] I read and followed the [contribution guidelines](https://github.com/OneLiteFeatherNET/.github/blob/main/CONTRIBUTING.md).

